### PR TITLE
Upgrade gulpicon to fix errors on macOS Sierra

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "glob": "^6.0.1",
     "gulp-util": "^3.0.7",
-    "gulpicon": "^0.1.2"
+    "gulpicon": "^1.2.1"
   }
 }


### PR DESCRIPTION
Grunticon fails on macOS Sierra. Issue was originally reported in https://github.com/filamentgroup/grunticon-lib/issues/26 and resolved in https://github.com/filamentgroup/gulpicon/issues/8.

Just upgraded the dependency here so other macOS Sierra users don't have issues.